### PR TITLE
Download JSON sources files and content files for CIL Harvesting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+### CIL Harvesting
+This repository will download the source JSON files and content files for CIL harvesting from the github repository CIL_Public_Data_JSON. And the JSON source files will be converted to CSV format and stored in dams-staging.
+
+##### Set up and run
+###### Clone CIL_Public_Data_JSON
+`git clone git@github.com:slash-segmentation/CIL_Public_Data_JSON.git`
+
+###### Clone CIL-Sync repository
+`git clone https://github.com/ucsdlib/cil-sync.git`
+
+###### Run the script
+```
+cd cil-sync
+chmod 755 ./git_changes.sh
+./git_changes.sh /path/to/CIL_Public_Data_JSON /pub/data2/damsmanager/dams-staging/rdcp-staging/rdcp-0126-cil
+```
+
+##### Files location
+JSON Source files
+`dams-staging/rdcp-staging/rdcp-0126-cil/cil_harvest_[YYYY-MM-DD]/metadata_source`
+
+Content files
+`dams-staging/rdcp-staging/rdcp-0126-cil/cil_harvest_[YYYY-MM-DD]/content_files`
+
+Processed files (CSV)
+`dams-staging/rdcp-staging/rdcp-0126-cil/cil_harvest_[YYYY-MM-DD]/metadata_processed`
+

--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ JSON Source files
 Content files
 `dams-staging/rdcp-staging/rdcp-0126-cil/cil_harvest_[YYYY-MM-DD]/content_files`
 
-Processed files (CSV)
+Processed files
 `dams-staging/rdcp-staging/rdcp-0126-cil/cil_harvest_[YYYY-MM-DD]/metadata_processed`
 

--- a/cil_csv.rb
+++ b/cil_csv.rb
@@ -9,16 +9,17 @@ require 'csv'
 
 # Hackety hacks, don't talk back
 class CilCSV
-  DATA_PATH = 'CIL_Public_Data_JSON/Version8_6/DATA/CIL_PUBLIC_DATA'.freeze
-  attr_reader :cil_data
+  attr_reader :cil_data, :data_path, :processed_path, :harvest_dir
 
-  def initialize
+  def initialize(harvest_dir)
     @cil_data = {}
+    @data_path = "#{harvest_dir}/metadata_source"
+    @processed_path = "#{harvest_dir}/metadata_processed"
   end
 
   def start
     load_data
-    CSV.open('cil.csv', 'wb', headers: true, write_headers: true, col_sep: '|') do |csv|
+    CSV.open("#{processed_path}/cil.csv", 'wb', headers: true, write_headers: true, col_sep: '|') do |csv|
       csv << ['Identifier'] + cil_header_row
       cil_value_rows.each { |row| csv << row }
     end
@@ -43,13 +44,12 @@ class CilCSV
   end
 
   def json_files
-    # For now just grab a couple samples
-    # Dir.children(DATA_PATH).take(500)
-    Dir.children(DATA_PATH)
+    # list all source json files
+    Dir.entries(data_path) - [".", ".."]
   end
 
   def parse(cil_file)
-    file = File.read(DATA_PATH + '/' + cil_file)
+    file = File.read(data_path + '/' + cil_file)
     metadata = JSON.parse(file)
     flatten_hash(metadata)
   end
@@ -67,4 +67,4 @@ class CilCSV
   end
 end
 
-CilCSV.new.start
+CilCSV.new(ARGV[1]).start

--- a/git_changes.sh
+++ b/git_changes.sh
@@ -19,8 +19,7 @@ mkdir -p "$harvest_dir/content_files"
 
 cd "$1" || exit 1
 
-#current_head=$(git log | head -1 | awk '{print $2}')
-current_head='f2967934ffb2a8d0dc17686650341fe6f976f094'
+current_head=$(git log | head -1 | awk '{print $2}')
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 
 git pull origin "$current_branch"
@@ -65,6 +64,3 @@ fi
 
 # download JSON source files and content files
 ruby "$dir/cil_download.rb" -e "$harvest_dir" "$source_files" > "$dir/log.txt"
-
-# convert JSON source file to CSV format
-ruby "$dir/cil_csv.rb" -e "$harvest_dir" > "$dir/log.txt"

--- a/git_changes.sh
+++ b/git_changes.sh
@@ -1,20 +1,70 @@
 #!/bin/bash
 #
-# Example usage: ./git_changes.sh $HOME/CIL_Public_Data_JSON
+# Example usage: ./git_changes.sh $HOME/CIL_Public_Data_JSON /pub/data2/dams/dams-staging/rdcp-staging/rdcp-0126-cil
+
+dir=$(pwd)
 
 if [ -z "$1" ]; then echo "No project directory provided"; exit 1; fi
+if [ -z "$2" ]; then echo "No rdcp-staging base directory provided"; exit 1; fi
+
+files_count=$(find $2 -path "*/metadata_source/*" -type f -name "*.json" | wc -l)
+echo "$files_count files"
+
+# base directory in rdcp staging for this CIL harvesting
+harvest_dir="$2/cil_harvest_$(date +%F)"
+mkdir -p "$harvest_dir"
+mkdir -p "$harvest_dir/metadata_source"
+mkdir -p "$harvest_dir/metadata_processed"
+mkdir -p "$harvest_dir/content_files"
+
 cd "$1" || exit 1
 
-current_head=$(git log | head -1 | awk '{print $2}')
+#current_head=$(git log | head -1 | awk '{print $2}')
+current_head='f2967934ffb2a8d0dc17686650341fe6f976f094'
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 
 git pull origin "$current_branch"
 
 new_head=$(git log | head -1 | awk '{print $2}')
-if [[ "$current_head" == "$new_head" ]]; then
+if [ "$current_head" == "$new_head" -a "$files_count" -gt 0 ]; then
   echo "No new commits have been added"
   exit 0
 fi
 
-new_files=$(git diff --name-only --diff-filter=A "$current_head".."$new_head")
-echo "$new_files"
+source_files="$harvest_dir/metadata_processed/json_files.txt"
+
+# Process json files added
+if [ $files_count -gt 0 ]; then
+  # unset rename limits for large batch of files
+  git config diff.renames 0
+
+  echo "git diff --name-only --diff-filter=A $current_head..$new_head"
+
+  diff_files=$(git diff --name-only --diff-filter=A "$current_head".."$new_head")
+
+  # insert diff files into array
+  eval "files=($diff_files)"
+
+  # loop through all file in the array
+  for f in "${files[@]}"
+  do
+    if [[ $f == *"/DATA/"* ]]; then
+      echo "$f"
+      # insert new json file with path
+      echo "$1/$f\n" >> $source_files
+    fi
+  done
+else
+  # Initial set up to process all files
+  new_files=$(find $1 -path "*/Version*/DATA/*" -type f -name "*.json")
+  echo "$new_files"
+
+  # insert new json file with path
+  echo "$new_files" >> $source_files
+fi
+
+# download JSON source files and content files
+ruby "$dir/cil_download.rb" -e "$harvest_dir" "$source_files" > "$dir/log.txt"
+
+# convert JSON source file to CSV format
+ruby "$dir/cil_csv.rb" -e "$harvest_dir" > "$dir/log.txt"


### PR DESCRIPTION
Fixes ucsdlib/damsmanager#297

Download JSON sources files and content files for CIL Harvesting, including function convert it to JSON source to CSV format.

For first time initializing, all JSON files in Github https://github.com/slash-segmentation/CIL_Public_Data_JSON will be downloaded and processed. And after initialization, running script git_changes.sh (`./git_changes.sh /path/to/CIL_Public_Data_JSON /pub/data2/damsmanager/dams-staging/rdcp-staging/rdcp-0126-cil`) will only retrieve the new JSON file added since running the script last time.

@mcritchlow / @ucsdlib/developers Please review.